### PR TITLE
Fix issue where grabbing Int from UInt8 directly break the int

### DIFF
--- a/CryptoSwift/PKCS7.swift
+++ b/CryptoSwift/PKCS7.swift
@@ -35,11 +35,12 @@ public struct PKCS7: Padding {
     }
     
     public func remove(bytes: [UInt8], blockSize:Int? = nil) -> [UInt8] {
-        let lastByte = bytes.last!
-        var padding = Int(lastByte) // last byte
-        
-        if padding >= 1 { //TODO: need test for that, what about empty padding
-            return Array(bytes[0..<(bytes.count - padding)])
+        if let last = bytes.last {
+            
+            var padding = Int(last) // last byte
+            if padding >= 1 { //TODO: need test for that, what about empty padding
+                return Array(bytes[0..<(bytes.count - padding)])
+            }
         }
         return bytes
     }


### PR DESCRIPTION

There seems to be some issue where getting the last (optional) item from the bytes array, causes a garbled integer. 

By wrapping the `last` call in a optional check, it also fixes a possible crash when the bytes array is empty.